### PR TITLE
DatePickerの追加と結果の表示

### DIFF
--- a/app/src/main/java/com/example/favoritelistapplication/ui/favList/FavListFragment.kt
+++ b/app/src/main/java/com/example/favoritelistapplication/ui/favList/FavListFragment.kt
@@ -20,6 +20,7 @@ class FavListFragment : Fragment() {
 
     private val homeViewModel: FavListViewModel by viewModels()
     private lateinit var binding: FragmentFavListBinding
+    private var isClicked: Boolean = false
 
     private val rotateOpen: Animation by lazy {
         AnimationUtils.loadAnimation(
@@ -45,8 +46,6 @@ class FavListFragment : Fragment() {
             R.anim.anim_to_button
         )
     }
-
-    private var isClicked: Boolean = false
 
     override fun onCreateView(
         inflater: LayoutInflater,

--- a/app/src/main/java/com/example/favoritelistapplication/ui/favRegister/AnniversaryDialogFragment.kt
+++ b/app/src/main/java/com/example/favoritelistapplication/ui/favRegister/AnniversaryDialogFragment.kt
@@ -1,0 +1,40 @@
+package com.example.favoritelistapplication.ui.favRegister
+
+import android.app.DatePickerDialog
+import android.app.Dialog
+import android.os.Bundle
+import android.widget.DatePicker
+import androidx.core.os.bundleOf
+import androidx.fragment.app.DialogFragment
+import com.example.favoritelistapplication.R
+import dagger.hilt.android.AndroidEntryPoint
+import java.util.*
+
+@AndroidEntryPoint
+class AnniversaryDialogFragment : DialogFragment(), DatePickerDialog.OnDateSetListener {
+
+    override fun onCreateDialog(savedInstanceState: Bundle?): Dialog {
+        val calendar = Calendar.getInstance()
+        val year = calendar.get(Calendar.YEAR)
+        val month = calendar.get(Calendar.MONTH)
+        val day = calendar.get(Calendar.DAY_OF_MONTH)
+
+        return context?.let {
+            DatePickerDialog(
+                it,
+                R.style.Style_customDatePicker,
+                this,
+                year,
+                month,
+                day
+            )
+        } ?: throw IllegalStateException()
+    }
+
+    override fun onDateSet(view: DatePicker?, year: Int, month: Int, dayOfMonth: Int) {
+        // よくわからないが選択した月-1がのデータが得られるので+1にしてある
+        val date = "${year}年${month + 1}月${dayOfMonth}日"
+        fragmentManager?.setFragmentResult("reqAnni", bundleOf("bundleAnni" to date))
+    }
+
+}

--- a/app/src/main/java/com/example/favoritelistapplication/ui/favRegister/AnniversaryDialogFragment.kt
+++ b/app/src/main/java/com/example/favoritelistapplication/ui/favRegister/AnniversaryDialogFragment.kt
@@ -6,12 +6,14 @@ import android.os.Bundle
 import android.widget.DatePicker
 import androidx.core.os.bundleOf
 import androidx.fragment.app.DialogFragment
+import androidx.fragment.app.activityViewModels
 import com.example.favoritelistapplication.R
 import dagger.hilt.android.AndroidEntryPoint
 import java.util.*
 
 @AndroidEntryPoint
 class AnniversaryDialogFragment : DialogFragment(), DatePickerDialog.OnDateSetListener {
+    private val viewModel: FavRegisterViewModel by activityViewModels()
 
     override fun onCreateDialog(savedInstanceState: Bundle?): Dialog {
         val calendar = Calendar.getInstance()
@@ -33,8 +35,7 @@ class AnniversaryDialogFragment : DialogFragment(), DatePickerDialog.OnDateSetLi
 
     override fun onDateSet(view: DatePicker?, year: Int, month: Int, dayOfMonth: Int) {
         // よくわからないが選択した月-1がのデータが得られるので+1にしてある
-        val date = "${year}年${month + 1}月${dayOfMonth}日"
-        fragmentManager?.setFragmentResult("reqAnni", bundleOf("bundleAnni" to date))
+        viewModel.registerAnniversary(year, month + 1, dayOfMonth)
     }
 
 }

--- a/app/src/main/java/com/example/favoritelistapplication/ui/favRegister/BirthdayDialogFragment.kt
+++ b/app/src/main/java/com/example/favoritelistapplication/ui/favRegister/BirthdayDialogFragment.kt
@@ -5,14 +5,15 @@ import android.app.Dialog
 import android.os.Bundle
 import android.view.View
 import android.widget.DatePicker
-import androidx.core.os.bundleOf
 import androidx.fragment.app.DialogFragment
+import androidx.fragment.app.activityViewModels
 import com.example.favoritelistapplication.R
 import dagger.hilt.android.AndroidEntryPoint
 import java.util.*
 
 @AndroidEntryPoint
 class BirthdayDialogFragment : DialogFragment(), DatePickerDialog.OnDateSetListener {
+    private val viewModel: FavRegisterViewModel by activityViewModels()
 
     override fun onCreateDialog(savedInstanceState: Bundle?): Dialog {
         val calendar = Calendar.getInstance()
@@ -38,8 +39,7 @@ class BirthdayDialogFragment : DialogFragment(), DatePickerDialog.OnDateSetListe
 
     override fun onDateSet(view: DatePicker?, year: Int, month: Int, dayOfMonth: Int) {
         // よくわからないが選択した月-1がのデータが得られるので+1にしてある
-        val date = "${month + 1}月${dayOfMonth}日"
-        fragmentManager?.setFragmentResult("reqBirth", bundleOf("bundleBirth" to date))
+        viewModel.registerBirthday(month + 1, dayOfMonth)
     }
 
 }

--- a/app/src/main/java/com/example/favoritelistapplication/ui/favRegister/BirthdayDialogFragment.kt
+++ b/app/src/main/java/com/example/favoritelistapplication/ui/favRegister/BirthdayDialogFragment.kt
@@ -1,0 +1,46 @@
+package com.example.favoritelistapplication.ui.favRegister
+
+import android.app.DatePickerDialog
+import android.app.Dialog
+import android.os.Bundle
+import android.util.Log
+import android.view.View
+import android.widget.DatePicker
+import androidx.core.os.bundleOf
+import androidx.fragment.app.DialogFragment
+import com.example.favoritelistapplication.R
+import dagger.hilt.android.AndroidEntryPoint
+import java.util.*
+
+@AndroidEntryPoint
+class BirthdayDialogFragment : DialogFragment(), DatePickerDialog.OnDateSetListener {
+
+    override fun onCreateDialog(savedInstanceState: Bundle?): Dialog {
+        val calendar = Calendar.getInstance()
+        val year = calendar.get(Calendar.YEAR)
+        val month = calendar.get(Calendar.MONTH)
+        val day = calendar.get(Calendar.DAY_OF_MONTH)
+
+        val dialog = context?.let {
+            DatePickerDialog(
+                it,
+                R.style.Style_customDatePicker,
+                this,
+                year,
+                month,
+                day
+            )
+        } ?: throw IllegalStateException()
+        val goneYear = dialog.datePicker.findViewById<View>(resources.getIdentifier("year", "id", "android"))
+        goneYear.visibility = View.GONE
+
+        return dialog
+    }
+
+    override fun onDateSet(view: DatePicker?, year: Int, month: Int, dayOfMonth: Int) {
+        // よくわからないが選択した月-1がのデータが得られるので+1にしてある
+        val date = "${month + 1}月${dayOfMonth}日"
+        fragmentManager?.setFragmentResult("reqBirth", bundleOf("bundleBirth" to date))
+    }
+
+}

--- a/app/src/main/java/com/example/favoritelistapplication/ui/favRegister/BirthdayDialogFragment.kt
+++ b/app/src/main/java/com/example/favoritelistapplication/ui/favRegister/BirthdayDialogFragment.kt
@@ -3,7 +3,6 @@ package com.example.favoritelistapplication.ui.favRegister
 import android.app.DatePickerDialog
 import android.app.Dialog
 import android.os.Bundle
-import android.util.Log
 import android.view.View
 import android.widget.DatePicker
 import androidx.core.os.bundleOf

--- a/app/src/main/java/com/example/favoritelistapplication/ui/favRegister/FavRegisterFragment.kt
+++ b/app/src/main/java/com/example/favoritelistapplication/ui/favRegister/FavRegisterFragment.kt
@@ -5,6 +5,7 @@ import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import androidx.fragment.app.Fragment
+import androidx.fragment.app.activityViewModels
 import androidx.fragment.app.viewModels
 import com.example.favoritelistapplication.databinding.FragmentFavRegisterBinding
 import dagger.hilt.android.AndroidEntryPoint
@@ -12,7 +13,7 @@ import dagger.hilt.android.AndroidEntryPoint
 @AndroidEntryPoint
 class FavRegisterFragment : Fragment() {
 
-    private val FavRegisterViewModel: FavRegisterViewModel by viewModels()
+    private val viewModel: FavRegisterViewModel by activityViewModels()
     private lateinit var binding: FragmentFavRegisterBinding
 
     override fun onCreateView(
@@ -31,8 +32,8 @@ class FavRegisterFragment : Fragment() {
         binding.btFavAnniversary.setOnClickListener {
             showAnniversaryDialog()
         }
-        childFragmentManager.setFragmentResultListener("reqAnni", viewLifecycleOwner) { key, bundle ->
-            val anniversary = bundle.getString("bundleAnni")
+
+        viewModel.anniversary.observe(viewLifecycleOwner){ anniversary ->
             binding.btFavAnniversary.text = anniversary
         }
 
@@ -40,8 +41,8 @@ class FavRegisterFragment : Fragment() {
         binding.btFavBirthday.setOnClickListener {
             showBirthdayDialog()
         }
-        childFragmentManager.setFragmentResultListener("reqBirth", viewLifecycleOwner) { key, bundle ->
-            val birthday = bundle.getString("bundleBirth")
+
+        viewModel.birthday.observe(viewLifecycleOwner){ birthday ->
             binding.btFavBirthday.text = birthday
         }
 

--- a/app/src/main/java/com/example/favoritelistapplication/ui/favRegister/FavRegisterFragment.kt
+++ b/app/src/main/java/com/example/favoritelistapplication/ui/favRegister/FavRegisterFragment.kt
@@ -1,38 +1,75 @@
 package com.example.favoritelistapplication.ui.favRegister
 
+import android.app.DatePickerDialog
 import android.os.Bundle
+import android.util.Log
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
+import android.widget.DatePicker
 import androidx.fragment.app.Fragment
-import androidx.lifecycle.ViewModelProvider
+import androidx.fragment.app.viewModels
 import com.example.favoritelistapplication.databinding.FragmentFavRegisterBinding
 import dagger.hilt.android.AndroidEntryPoint
 
 @AndroidEntryPoint
 class FavRegisterFragment : Fragment() {
 
-    private lateinit var notificationsViewModel: FavRegisterViewModel
-    private var _binding: FragmentFavRegisterBinding? = null
-
-    private val binding get() = _binding!!
+    private val FavRegisterViewModel: FavRegisterViewModel by viewModels()
+    private lateinit var binding: FragmentFavRegisterBinding
 
     override fun onCreateView(
         inflater: LayoutInflater,
         container: ViewGroup?,
         savedInstanceState: Bundle?
-    ): View? {
-        notificationsViewModel =
-            ViewModelProvider(this).get(FavRegisterViewModel::class.java)
+    ): View {
+        binding = FragmentFavRegisterBinding.inflate(inflater, container, false)
 
-        _binding = FragmentFavRegisterBinding.inflate(inflater, container, false)
-        val root: View = binding.root
-
-        return root
+        return binding.root
     }
 
-    override fun onDestroyView() {
-        super.onDestroyView()
-        _binding = null
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        super.onViewCreated(view, savedInstanceState)
+
+        binding.btFavAnniversary.setOnClickListener {
+            showAnniversaryDialog()
+        }
+        binding.btFavBirthday.setOnClickListener {
+            showBirthdayDialog()
+        }
+
+        childFragmentManager?.setFragmentResultListener("reqAnni", viewLifecycleOwner) { key, bundle ->
+            val anniversary = bundle.getString("bundleAnni")
+            binding.btFavAnniversary.text = anniversary
+        }
+
+        childFragmentManager?.setFragmentResultListener("reqBirth", viewLifecycleOwner) { key, bundle ->
+            val birthday = bundle.getString("bundleBirth")
+            binding.btFavBirthday.text = birthday
+        }
     }
+
+    private fun showAnniversaryDialog() {
+        val anniversaryDialog = AnniversaryDialogFragment()
+        activity?.supportFragmentManager?.let {
+            anniversaryDialog.show(
+                childFragmentManager,
+                "datePicker"
+            )
+        }
+            ?: throw IllegalStateException()
+    }
+
+    private fun showBirthdayDialog() {
+        val birthdayDialog = BirthdayDialogFragment()
+        activity?.supportFragmentManager?.let {
+            birthdayDialog.show(
+                childFragmentManager,
+                "datePicker"
+            )
+        }
+            ?: throw IllegalStateException()
+    }
+
+
 }

--- a/app/src/main/java/com/example/favoritelistapplication/ui/favRegister/FavRegisterFragment.kt
+++ b/app/src/main/java/com/example/favoritelistapplication/ui/favRegister/FavRegisterFragment.kt
@@ -1,12 +1,9 @@
 package com.example.favoritelistapplication.ui.favRegister
 
-import android.app.DatePickerDialog
 import android.os.Bundle
-import android.util.Log
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
-import android.widget.DatePicker
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.viewModels
 import com.example.favoritelistapplication.databinding.FragmentFavRegisterBinding
@@ -34,19 +31,21 @@ class FavRegisterFragment : Fragment() {
         binding.btFavAnniversary.setOnClickListener {
             showAnniversaryDialog()
         }
-        binding.btFavBirthday.setOnClickListener {
-            showBirthdayDialog()
-        }
-
-        childFragmentManager?.setFragmentResultListener("reqAnni", viewLifecycleOwner) { key, bundle ->
+        childFragmentManager.setFragmentResultListener("reqAnni", viewLifecycleOwner) { key, bundle ->
             val anniversary = bundle.getString("bundleAnni")
             binding.btFavAnniversary.text = anniversary
         }
 
-        childFragmentManager?.setFragmentResultListener("reqBirth", viewLifecycleOwner) { key, bundle ->
+
+        binding.btFavBirthday.setOnClickListener {
+            showBirthdayDialog()
+        }
+        childFragmentManager.setFragmentResultListener("reqBirth", viewLifecycleOwner) { key, bundle ->
             val birthday = bundle.getString("bundleBirth")
             binding.btFavBirthday.text = birthday
         }
+
+
     }
 
     private fun showAnniversaryDialog() {

--- a/app/src/main/java/com/example/favoritelistapplication/ui/favRegister/FavRegisterViewModel.kt
+++ b/app/src/main/java/com/example/favoritelistapplication/ui/favRegister/FavRegisterViewModel.kt
@@ -4,13 +4,24 @@ import androidx.lifecycle.LiveData
 import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.ViewModel
 import dagger.hilt.android.lifecycle.HiltViewModel
+import java.util.*
 import javax.inject.Inject
 
 @HiltViewModel
 class FavRegisterViewModel @Inject internal constructor() : ViewModel() {
+    private val _birthday: MutableLiveData<String> = MutableLiveData()
+    val birthday: LiveData<String> = _birthday
 
-    private val _text = MutableLiveData<String>().apply {
-        value = "This is notifications Fragment"
+    private val _anniversary: MutableLiveData<String> = MutableLiveData()
+    val anniversary: LiveData<String> = _anniversary
+
+    fun registerBirthday(month: Int, date: Int){
+        _birthday.value = "${month}月${date}日"
+
     }
-    val text: LiveData<String> = _text
+
+    fun registerAnniversary(year: Int, month: Int, date: Int){
+        _anniversary.value = "${year}年${month}月${date}日"
+
+    }
 }

--- a/app/src/main/res/values-night/themes.xml
+++ b/app/src/main/res/values-night/themes.xml
@@ -20,4 +20,14 @@
     </style>
 
     <style name="Theme.FavoriteListApplication.ActionBarOverlay" parent="ThemeOverlay.MaterialComponents.Dark.ActionBar" />
+
+    <!-- Dialog -> Picker -->
+    <style name="Style.customDatePicker" parent="Theme.AppCompat.Light.Dialog.Alert">
+        <item name="android:datePickerStyle">@style/customDatePicker</item>
+    </style>
+
+    <style name="customDatePicker" parent="@android:style/Widget.Material.Light.DatePicker">
+        <item name="android:datePickerMode">spinner</item>
+        <item name="android:calendarViewShown">false</item>
+    </style>
 </resources>

--- a/app/src/main/res/values/themes.xml
+++ b/app/src/main/res/values/themes.xml
@@ -20,4 +20,21 @@
     </style>
 
     <style name="Theme.FavoriteListApplication.ActionBarOverlay" parent="ThemeOverlay.MaterialComponents.Dark.ActionBar" />
+
+    <!-- Dialog -> Picker -->
+    <style name="Style.customDatePicker" parent="Theme.AppCompat.Light.Dialog.Alert">
+        <item name="android:datePickerStyle">@style/customDatePicker</item>
+        <item name="android:buttonBarButtonStyle">@style/customTextButton</item>
+
+    </style>
+
+    <style name="customDatePicker" parent="@style/Widget.MaterialComponents.MaterialCalendar">
+        <item name="android:datePickerMode">spinner</item>
+        <item name="android:calendarViewShown">false</item>
+        <item name="android:buttonBarButtonStyle">@style/customTextButton</item>
+    </style>
+
+    <style name="customTextButton" parent="@style/Widget.MaterialComponents.Button.TextButton.Dialog">
+        <item name="android:textColor">@color/black</item>
+    </style>
 </resources>


### PR DESCRIPTION
## 対応するissue

## 概要
- DatePickerの追加と結果の表示 

## 意図する動作内容（または変更点）
- アプリを起動し，FABからFavRegister画面に遷移する
- 記念日or誕生日を登録をタップするとDatePickerが起動する
- 記念日→年月日，誕生日→月日を選択できる
- 選択した日付がボタンのテキストとして表示される

## スクリーンショット（UI作成，変更時）
https://user-images.githubusercontent.com/38235279/132861334-ec52dad5-3e8d-4e3f-a835-f994c7777ad0.mp4

## その他
フラグメント間のデータ…
parentFragment，childFragmentではなく
ViewModelのほうがいいのかな…🤔
https://developer.android.com/guide/fragments/communicate#viewmodel